### PR TITLE
Update rancher provider to version 6.0.0

### DIFF
--- a/modules/rke2-cluster/main.tf
+++ b/modules/rke2-cluster/main.tf
@@ -5,7 +5,6 @@ resource "rancher2_cluster_v2" "rke2_cluster" {
   kubernetes_version = var.kubernetes_version
   enable_network_policy = var.enable_network_policy
   default_cluster_role_for_project_members = "user"
-  default_pod_security_policy_template_name = "unrestricted"
   labels = var.rke2_cluster_labels
  rke_config {
     etcd {

--- a/modules/rke2-cluster/main.tf
+++ b/modules/rke2-cluster/main.tf
@@ -6,7 +6,7 @@ resource "rancher2_cluster_v2" "rke2_cluster" {
   enable_network_policy = var.enable_network_policy
   default_cluster_role_for_project_members = "user"
   labels = var.rke2_cluster_labels
- rke_config {
+  rke_config {
     etcd {
         disable_snapshots = false
         snapshot_retention = 5
@@ -33,9 +33,6 @@ resource "rancher2_cluster_v2" "rke2_cluster" {
     upgrade_strategy {
         control_plane_concurrency =  "1"
         worker_concurrency =  "1"
-    }
-    machine_selector_config{
-        config = {cloud_provider_name: "none"}
     }
     registries {}
   }

--- a/modules/rke2-cluster/providers.tf
+++ b/modules/rke2-cluster/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.25.0"
+      version = "6.0.0"
     }
     }
 }

--- a/modules/rke2-cluster/variables.tf
+++ b/modules/rke2-cluster/variables.tf
@@ -1,7 +1,3 @@
-variable cloud_credential_name {
-   type = string
-   description = "openstack cloud credential name for rancher, this is a bug from rancher. just create an empty cloud credential named test in rancher"
-}
 variable cluster_name {
    type = string
    description = "name of the rke cluster"

--- a/modules/rke2-openstack-machine-config/main.tf
+++ b/modules/rke2-openstack-machine-config/main.tf
@@ -1,7 +1,3 @@
-data "rancher2_cloud_credential" "cloud_credential_name" {
-    name = var.cloud_credential_name
-}
-
 # Create openstack machine config v2
 resource "rancher2_machine_config_v2" "machine" {
   generate_name       = var.machine_config_name

--- a/modules/rke2-openstack-machine-config/providers.tf
+++ b/modules/rke2-openstack-machine-config/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.25.0"
+      version = "6.0.0"
     }
     }
 }   

--- a/modules/rke2-openstack-machine-config/variables.tf
+++ b/modules/rke2-openstack-machine-config/variables.tf
@@ -1,8 +1,4 @@
 ## Openstack Cloud variables
-variable cloud_credential_name {
-   type = string
-   description = "openstack cloud credential name for rancher, this is a bug that we are aware of. just create an empty cloud credential named test in rancher"
-}
 variable machine_config_name {
    type = string
    default = "node-config"


### PR DESCRIPTION
Updated Rancher provider version for rke2-cluster and rke2-openstack-machine-config modules only. 
Tested with Terraform v1.10.5 on linux_amd64.

