### PR TITLE
Update: add taints variable and cluster_v1_id output

### DIFF
--- a/modules/rke2-cluster/main.tf
+++ b/modules/rke2-cluster/main.tf
@@ -26,6 +26,14 @@ resource "rancher2_cluster_v2" "rke2_cluster" {
           kind = machine_pools.value.machine_config.kind
           name = machine_pools.value.machine_config.name
         }
+        dynamic "taints" {
+          for_each = machine_pools.value.taints
+            content {
+              key    = taints.value.key
+              value  = taints.value.value
+              effect = taints.value.effect
+            }
+        }
       }
     }
     machine_global_config = var.machine_global_config

--- a/modules/rke2-cluster/outputs.tf
+++ b/modules/rke2-cluster/outputs.tf
@@ -2,6 +2,10 @@ output "rancher_cluster_id" {
   value = rancher2_cluster_v2.rke2_cluster.id
 }
 
+output "rancher_cluster_v1_id" {
+  value = rancher2_cluster_v2.rke2_cluster.cluster_v1_id
+}
+
 output "cluster_name" {
   value = rancher2_cluster_v2.rke2_cluster.name
 }

--- a/modules/rke2-cluster/variables.tf
+++ b/modules/rke2-cluster/variables.tf
@@ -20,6 +20,11 @@ variable "machine_pools" {
     control_plane_role        = bool
     etcd_role                 = bool
     worker_role               = bool
+    taints                    = optional(list(object({
+        key = string
+        value = string
+        effect = string
+    })), [])
     quantity                  = number
     machine_config = object({
       kind = string


### PR DESCRIPTION
- Enable support for adding taints to cluster machines
- Return the cluster_v1_id attribute of rancher2_cluster_v2 resource, to be used with rancher2_sync